### PR TITLE
feat(cicd): GitHub ActionsでGitHub Pagesへのデプロイパイプライン構築

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # mainブランチへのpush時のみ実行
+  workflow_dispatch: # 手動実行も可能にする
+
+permissions:
+  contents: read
+  pages: write # pagesへの書き込み権限
+  id-token: write # OIDCトークンへの書き込み権限 (actions/deploy-pages@v4 で必要)
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20" # プロジェクトで使用するNode.jsバージョン
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint with Biome
+        run: npx @biomejs/biome check .
+      - name: Type check with TypeScript
+        run: npm run type-check
+      - name: Build with Next.js
+        run: npm run build
+        env:
+          # GitHub Pagesのサブディレクトリ対応のため、環境変数NEXT_PUBLIC_BASE_PATHを設定
+          # next.config.jsのbasePathとassetPrefixがこれを利用するように変更も可能だが、
+          # 今回はnext.config.jsに直接記述しているのでここでは不要。
+          # もしnext.config.jsでprocess.envを参照する場合はここで設定する。
+          # NEXT_PUBLIC_BASE_PATH: /nblm-collector
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out # Next.jsのビルド出力ディレクトリ
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/COMMIT_EDITMSG
+++ b/COMMIT_EDITMSG
@@ -1,9 +1,13 @@
-feat(setup): Next.js初期セットアップとBiome導入
+feat(cicd): GitHub ActionsでGitHub Pagesへのデプロイパイプライン構築
 
-- create-next-app を使用してNext.jsプロジェクトを初期化
-  - TypeScript, Tailwind CSS, App Router, srcディレクトリ構成
-- Biomeを導入し、フォーマッターとリンターを設定
-  - ESLint関連の設定ファイルは削除
-- src/components ディレクトリを作成
+- mainブランチへのpush時および手動実行時にワークフローがトリガーされる
+- Node.jsセットアップ、依存関係インストール
+- Biomeでのリントチェック実行
+- TypeScriptでの型チェック実行
+- Next.jsアプリケーションのビルド (静的エクスポート向け設定)
+- ビルド成果物をアップロードし、GitHub Pagesへデプロイ
 
-Closes #2 
+- `next.config.ts` に `output: 'export'` およびGitHub Pages用 `basePath`, `assetPrefix` を設定
+- `package.json` に `type-check` スクリプトを追加
+
+Closes #3 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
-import type { NextConfig } from 'next'
+import type { NextConfig } from "next";
+
+const repoName = "nblm-collector"; // リポジトリ名
 
 const nextConfig: NextConfig = {
-  /* config options here */
-}
+  output: "export", // 静的エクスポートを有効化
+  // GitHub Pagesのサブディレクトリ対応
+  basePath: `/${repoName}`,
+  assetPrefix: `/${repoName}/`,
+  // assetPrefix を使う場合、画像の最適化を無効にする必要がある
+  images: {
+    unoptimized: true,
+  },
+};
 
-export default nextConfig
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "next": "15.3.2",


### PR DESCRIPTION
## 概要
Issue #3 の実装として、GitHub Actions を使用して GitHub Pages への CI/CD パイプラインを構築しました。

## 変更内容
- `main` ブランチへの push 時および手動実行 (`workflow_dispatch`) 時にトリガーされるワークフロー (`.github/workflows/deploy.yml`) を作成。
- ワークフロー内のジョブ:
  - コードのチェックアウト
  - Node.js のセットアップ (v20) および npm キャッシュの有効化
  - 依存関係のインストール (`npm ci`)
  - Biome によるリントおよびフォーマットチェック (`npx @biomejs/biome check .`)
  - TypeScript による型チェック (`npm run type-check`)
  - Next.js アプリケーションのビルド (`npm run build`)
  - ビルド成果物 (`./out` ディレクトリ) のアーティファクトとしてのアップロード (`actions/upload-pages-artifact@v3`)
  - GitHub Pages へのデプロイ (`actions/deploy-pages@v4`)
- `next.config.ts` を更新:
  - `output: 'export'` を設定し、静的エクスポートを有効化。
  - GitHub Pages のサブディレクトリ (`/<reponame>/`) で正しく表示されるように `basePath` と `assetPrefix` を設定。
  - `assetPrefix` 使用時の画像最適化を無効化 (`images: { unoptimized: true }`)。
- `package.json` の `scripts` に `type-check` (`tsc --noEmit`) を追加。

## 確認事項
- このPRが `main` にマージされた後、GitHub リポジトリの Settings > Pages で、Source を "GitHub Actions" に設定する必要があります。
- 初回デプロイ後、公開されたURL (`https://sotaroNishioka.github.io/nblm-collector/`) で表示が正しいか確認してください。

Closes #3