### PR TITLE
fix(cicd): Remove invalid env block from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,12 +34,6 @@ jobs:
         run: npm run type-check
       - name: Build with Next.js
         run: npm run build
-        env:
-          # GitHub Pagesのサブディレクトリ対応のため、環境変数NEXT_PUBLIC_BASE_PATHを設定
-          # next.config.jsのbasePathとassetPrefixがこれを利用するように変更も可能だが、
-          # 今回はnext.config.jsに直接記述しているのでここでは不要。
-          # もしnext.config.jsでprocess.envを参照する場合はここで設定する。
-          # NEXT_PUBLIC_BASE_PATH: /nblm-collector
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/COMMIT_EDITMSG
+++ b/COMMIT_EDITMSG
@@ -11,3 +11,10 @@ feat(cicd): GitHub ActionsでGitHub Pagesへのデプロイパイプライン構
 - `package.json` に `type-check` スクリプトを追加
 
 Closes #3 
+
+fix(cicd): Remove invalid env block from deploy workflow
+
+The env block under the 'Build with Next.js' step contained only
+comments, causing a YAML parsing error. This block was not needed
+as environment variables for basePath and assetPrefix are handled
+directly in next.config.ts. 


### PR DESCRIPTION
## 概要
GitHub Actions の `deploy.yml` ワークフローで発生していたYAML構文エラーを修正しました。

## 変更内容
- `.github/workflows/deploy.yml` の `Build with Next.js` ステップから、不要かつ構文エラーの原因となっていた `env:` ブロックを削除しました。
- この `env:` ブロックはコメントのみを含んでおり、実際の環境変数を設定していませんでした。`basePath` や `assetPrefix` に関する設定は `next.config.ts` で直接行われているため、ワークフローでの `env` 設定は不要です。

## 確認事項
- この修正により、ワークフローが正常に解析され、実行されるようになるはずです。
- マージ後、再度 `main` ブランチでのActionの動作を確認してください。