### PR TITLE
fix(format): Reapply Biome formatting to next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,9 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
-const repoName = "nblm-collector"; // リポジトリ名
+const repoName = 'nblm-collector' // リポジトリ名
 
 const nextConfig: NextConfig = {
-  output: "export", // 静的エクスポートを有効化
+  output: 'export', // 静的エクスポートを有効化
   // GitHub Pagesのサブディレクトリ対応
   basePath: `/${repoName}`,
   assetPrefix: `/${repoName}/`,
@@ -11,6 +11,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-};
+}
 
-export default nextConfig;
+export default nextConfig


### PR DESCRIPTION
## 概要
再度 Biome のフォーマットチェックエラーが発生した `next.config.ts` を修正しました。

## 変更内容
- `next.config.ts` ファイルに対して、Biome CLI を使用してフォーマットを再適用しました。
  - インポート文および文字列リテラルをシングルクォートに変更。
  - 不要な末尾セミコロンを削除。

## 確認事項
- この修正により、GitHub Actions の `biome check` ステップが正常に完了するはずです。
- マージ後、再度 `main` ブランチでのActionの動作を確認してください。

Related to #12