### PR TITLE
fix: Adjust asset paths for GitHub Pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,17 @@
-import type { NextConfig } from 'next'
+import type { NextConfig } from "next";
 
-const repoName = 'nblm-collector' // リポジトリ名
+const repoName = "nblm-collector"; // リポジトリ名
 
 const nextConfig: NextConfig = {
-  output: 'export', // 静的エクスポートを有効化
+  output: "export", // 静的エクスポートを有効化
   // GitHub Pagesのサブディレクトリ対応
   basePath: `/${repoName}`,
   assetPrefix: `/${repoName}/`,
+  trailingSlash: true, // 末尾スラッシュを強制
   // assetPrefix を使う場合、画像の最適化を無効にする必要がある
   images: {
     unoptimized: true,
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## 概要
GitHub Pages で画像などのアセットが正しく表示されない問題を修正するため、`next.config.ts` に `trailingSlash: true` を追加しました。

## 変更内容
- `next.config.ts` に `trailingSlash: true` を設定。

## 確認事項
- この変更により、GitHub Pages 上で画像が正しく表示されることを確認してください。
  - 例: `https://sotaroNishioka.github.io/nblm-collector/next.svg`
- マージ後、再度 `main` ブランチでの GitHub Actions のデプロイ結果と表示を確認してください。