### PR TITLE
fix: Apply assetPrefix and basePath conditionally for production

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,18 @@
-import type { NextConfig } from 'next'
+import type { NextConfig } from "next";
 
-const repoName = 'nblm-collector' // リポジトリ名
+const repoName = "nblm-collector"; // リポジトリ名
+const isProd = process.env.NODE_ENV === "production";
 
 const nextConfig: NextConfig = {
-  output: 'export', // 静的エクスポートを有効化
+  output: "export", // 静的エクスポートを有効化
   // GitHub Pagesのサブディレクトリ対応
-  basePath: `/${repoName}`,
-  assetPrefix: `/${repoName}/`,
+  basePath: isProd ? `/${repoName}` : "",
+  assetPrefix: isProd ? `/${repoName}/` : "",
   trailingSlash: true, // 末尾スラッシュを強制
   // assetPrefix を使う場合、画像の最適化を無効にする必要がある
   images: {
     unoptimized: true,
   },
-}
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## 概要
GitHub Pages で画像などのアセットが正しく表示されない問題を修正するため、`next.config.ts` の `basePath` と `assetPrefix` を本番環境でのみ設定するように変更しました。
このアプローチは、`my-blog` リポジトリの `next.config.js` を参考にしています。

## 変更内容
- `next.config.ts` を修正:
  - `process.env.NODE_ENV === 'production'` の場合にのみ `basePath` と `assetPrefix` にリポジトリ名を含むパスを設定。
  - 開発環境では `basePath` と `assetPrefix` を空文字列 `''` に設定。

## 確認事項
- この変更により、GitHub Actions でのビルド時に `biome check` が正常に完了すること。
- マージ後、GitHub Pages 上で画像が正しく表示されること (例: `https://sotaroNishioka.github.io/nblm-collector/next.svg`)。
- ローカル開発環境でも表示が崩れないこと。